### PR TITLE
fix: yaw velocity control

### DIFF
--- a/drone_mavsdk_control.orogen
+++ b/drone_mavsdk_control.orogen
@@ -31,6 +31,13 @@ task_context "MavDroneControlTask" do
     # UTM conversion parameters
     property "utm_parameters", "gps_base/UTMConversionParameters"
 
+    # Yaw to yaw speed proportional
+    #
+    # The mavsdk offboard plugin does not provide a way to control all velocities in the
+    # NED frame. The component emulates it by creating a constant differential in yaw,
+    # that is yaw = currentYaw + K_yaw_speed2yaw * yawSpeed
+    property "K_yaw_speed2yaw", "double", 0.1
+
     # Command sent to the drone
     input_port "cmd_action", "drone_control/CommandAction"
 

--- a/tasks/MavDroneControlTask.hpp
+++ b/tasks/MavDroneControlTask.hpp
@@ -139,6 +139,7 @@ argument.
         mavsdk::Offboard::Result mControllerStarted;
         gps_base::UTMConverter mUtmConverter;
         double mMaxDistanceFromSetpoint;
+        double mCurrentYaw;
         drone_control::Mission mLastMission;
 
         HealthStatus healthCheck(std::unique_ptr<mavsdk::Telemetry> const& telemetry);


### PR DESCRIPTION
The offboard velocity command is actually X/Y/Z velocity plus yaw
position. "Emulate" velocity by creating a "chasing" point in front
of the drone.